### PR TITLE
Add support for filecache in utility functions

### DIFF
--- a/pdstemplate/__init__.py
+++ b/pdstemplate/__init__.py
@@ -1130,8 +1130,8 @@ class PdsTemplate:
         """
 
         ##################################################################################
-        local_filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
-                                                     ## time, but it's better than a crash
+        local_filepath = FCPath(filepath).retrieve()
+        # Only warn for remote files where cached time is returned
         if local_filepath != filepath:
             filepath = local_filepath
             logger = get_logger()
@@ -1154,8 +1154,8 @@ class PdsTemplate:
         """
 
         ##################################################################################
-        local_filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
-                                                     ## time, but it's better than a crash
+        local_filepath = FCPath(filepath).retrieve()
+        # Only warn for remote files where cached time is returned
         if local_filepath != filepath:
             filepath = local_filepath
             logger = get_logger()

--- a/pdstemplate/__init__.py
+++ b/pdstemplate/__init__.py
@@ -851,14 +851,13 @@ class PdsTemplate:
         """The basename of `filepath`, with the leading directory path removed.
 
         Parameters:
-            filepath (str): The filepath.
+            filepath (Path | FCPath | str): The filepath.
 
         Returns:
             str: The basename of the filepath (the final filename).
         """
 
         return FCPath(filepath).name
-#        return os.path.basename(filepath)
 
     @staticmethod
     def BOOL(value, true='true', false='false'):
@@ -1050,14 +1049,14 @@ class PdsTemplate:
         """The size in bytes of the file specified by `filepath`.
 
         Parameters:
-            filepath (str): The filepath.
+            filepath (Path | FCPath | str): The filepath.
 
         Returns:
             int: The size in bytes of the file.
         """
 
-        filepath = FCPath(filepath).retrieve()
-        return os.path.getsize(filepath)
+        local_path = FCPath(filepath).retrieve()
+        return os.path.getsize(local_path)
 
     # From http://stackoverflow.com/questions/3431825/-
     @staticmethod
@@ -1065,15 +1064,15 @@ class PdsTemplate:
         """The MD5 checksum of the file specified by `filepath`.
 
         Parameters:
-            filepath (str): The filepath.
+            filepath (Path | FCPath | str): The filepath.
 
         Returns:
             str: The MD5 checksum of the file.
         """
 
-        filepath = FCPath(filepath).retrieve()
+        local_path = FCPath(filepath).retrieve()
         blocksize = 65536
-        with open(filepath, 'rb') as f:
+        with open(local_path, 'rb') as f:
             hasher = hashlib.md5()
             buf = f.read(blocksize)
             while len(buf) > 0:
@@ -1088,7 +1087,7 @@ class PdsTemplate:
         """The number of records in the the file specified by `filepath`.
 
         Parameters:
-            filepath (str): The filepath.
+            filepath (Path | FCPath | str): The filepath.
 
         Returns:
             int: The number of records in the file if it is ASCII;
@@ -1097,9 +1096,9 @@ class PdsTemplate:
 
         # We intentionally open this in non-binary mode so we don't have to contend with
         # line terminator issues.
-        filepath = FCPath(filepath).retrieve()
+        local_path = FCPath(filepath).retrieve()
         printable = string.printable.encode('latin8')
-        with open(filepath, 'rb') as f:
+        with open(local_path, 'rb') as f:
             count = 0
             asciis = 0
             non_asciis = 0
@@ -1122,23 +1121,14 @@ class PdsTemplate:
         """The modification time in the local time zone of a file.
 
         Parameters:
-            filepath (str): The filepath.
+            filepath (Path | FCPath | str): The filepath.
 
         Returns:
             str: The modification time in the local time zone of the file specified by
             `filepath` in the form "yyyy-mm-ddThh:mm:ss".
         """
 
-        ##################################################################################
-        local_filepath = FCPath(filepath).retrieve()
-        # Only warn for remote files where cached time is returned
-        if local_filepath != filepath:
-            filepath = local_filepath
-            logger = get_logger()
-            logger.warning(f'FILE_TIME reflects the cached time: {filepath}', force=True)
-        ##################################################################################
-#        timestamp = FCPath(filepath).stat().st_mtime  ### not implemented in FCPath
-        timestamp = os.path.getmtime(filepath)
+        timestamp = FCPath(filepath).modification_time()
         return datetime.datetime.fromtimestamp(timestamp).isoformat()[:19]
 
     @staticmethod
@@ -1146,23 +1136,14 @@ class PdsTemplate:
         """The UTC modification time of a file.
 
         Parameters:
-            filepath (str): The filepath.
+            filepath (Path | FCPath | str): The filepath.
 
         Returns:
             str: The UTC modification time of the file specified by `filepath` in the
             form "yyyy-mm-ddThh:mm:ssZ".
         """
 
-        ##################################################################################
-        local_filepath = FCPath(filepath).retrieve()
-        # Only warn for remote files where cached time is returned
-        if local_filepath != filepath:
-            filepath = local_filepath
-            logger = get_logger()
-            logger.warning(f'FILE_TIME reflects the cached time: {filepath}', force=True)
-        ##################################################################################
-#        timestamp = FCPath(filepath).stat().st_mtime  ### not implemented in FCPath
-        timestamp = os.path.getmtime(filepath)
+        timestamp = FCPath(filepath).modification_time()
         try:
             utc_dt = datetime.datetime.fromtimestamp(timestamp, datetime.UTC)
         except AttributeError:  # pragma: no cover
@@ -1278,14 +1259,14 @@ class PdsTemplate:
         terminators.
 
         Parameters:
-            filepath (str): The filepath.
+            filepath (Path | FCPath | str): The filepath.
         """
 
         # We intentionally open this in non-binary mode so we don't have to contend with
         # line terminator issues.
-        filepath = FCPath(filepath).retrieve()
+        local_path = FCPath(filepath).retrieve()
         max_bytes = 0
-        with open(filepath, 'rb') as f:
+        with open(local_path, 'rb') as f:
             for line in f:
                 max_bytes = max(max_bytes, len(line))
 

--- a/pdstemplate/__init__.py
+++ b/pdstemplate/__init__.py
@@ -1129,8 +1129,12 @@ class PdsTemplate:
             `filepath` in the form "yyyy-mm-ddThh:mm:ss".
         """
 
+        ##################################################################################
+        logger = get_logger()
+        logger.warning(f'FILE_TIME reflects the cached time: {filepath}', force=True)
         filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
                                                ## time, but it's better than a crash
+        ##################################################################################
 #        timestamp = FCPath(filepath).stat().st_mtime  ### not implemented in FCPath
         timestamp = os.path.getmtime(filepath)
         return datetime.datetime.fromtimestamp(timestamp).isoformat()[:19]
@@ -1147,8 +1151,12 @@ class PdsTemplate:
             form "yyyy-mm-ddThh:mm:ssZ".
         """
 
+        ##################################################################################
+        logger = get_logger()
+        logger.warning(f'FILE_TIME reflects the cached time: {filepath}', force=True)
         filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
                                                ## time, but it's better than a crash
+        ##################################################################################
 #        timestamp = FCPath(filepath).stat().st_mtime  ### not implemented in FCPath
         timestamp = os.path.getmtime(filepath)
         try:

--- a/pdstemplate/__init__.py
+++ b/pdstemplate/__init__.py
@@ -1078,7 +1078,6 @@ class PdsTemplate:
                 hasher.update(buf)
                 buf = f.read(blocksize)
 
-        f.close()
         return hasher.hexdigest()
 
     @staticmethod
@@ -1260,7 +1259,7 @@ class PdsTemplate:
             filepath (Path | FCPath | str): The filepath.
         """
 
-        # We intentionally open this in non-binary mode so we don't have to contend with
+        # We intentionally open this in binary mode so we don't have to contend with
         # line terminator issues.
         max_bytes = 0
         with FCPath(filepath).open('rb') as f:

--- a/pdstemplate/__init__.py
+++ b/pdstemplate/__init__.py
@@ -1130,10 +1130,12 @@ class PdsTemplate:
         """
 
         ##################################################################################
-        logger = get_logger()
-        logger.warning(f'FILE_TIME reflects the cached time: {filepath}', force=True)
-        filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
-                                               ## time, but it's better than a crash
+        local_filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
+                                                     ## time, but it's better than a crash
+        if local_filepath != filepath:
+            filepath = local_filepath
+            logger = get_logger()
+            logger.warning(f'FILE_TIME reflects the cached time: {filepath}', force=True)
         ##################################################################################
 #        timestamp = FCPath(filepath).stat().st_mtime  ### not implemented in FCPath
         timestamp = os.path.getmtime(filepath)
@@ -1152,10 +1154,12 @@ class PdsTemplate:
         """
 
         ##################################################################################
-        logger = get_logger()
-        logger.warning(f'FILE_TIME reflects the cached time: {filepath}', force=True)
-        filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
-                                               ## time, but it's better than a crash
+        local_filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
+                                                     ## time, but it's better than a crash
+        if local_filepath != filepath:
+            filepath = local_filepath
+            logger = get_logger()
+            logger.warning(f'FILE_TIME reflects the cached time: {filepath}', force=True)
         ##################################################################################
 #        timestamp = FCPath(filepath).stat().st_mtime  ### not implemented in FCPath
         timestamp = os.path.getmtime(filepath)

--- a/pdstemplate/__init__.py
+++ b/pdstemplate/__init__.py
@@ -1070,9 +1070,8 @@ class PdsTemplate:
             str: The MD5 checksum of the file.
         """
 
-        local_path = FCPath(filepath).retrieve()
         blocksize = 65536
-        with open(local_path, 'rb') as f:
+        with FCPath(filepath).open('rb') as f:
             hasher = hashlib.md5()
             buf = f.read(blocksize)
             while len(buf) > 0:
@@ -1096,9 +1095,8 @@ class PdsTemplate:
 
         # We intentionally open this in non-binary mode so we don't have to contend with
         # line terminator issues.
-        local_path = FCPath(filepath).retrieve()
         printable = string.printable.encode('latin8')
-        with open(local_path, 'rb') as f:
+        with FCPath(filepath).open('rb') as f:
             count = 0
             asciis = 0
             non_asciis = 0
@@ -1264,9 +1262,8 @@ class PdsTemplate:
 
         # We intentionally open this in non-binary mode so we don't have to contend with
         # line terminator issues.
-        local_path = FCPath(filepath).retrieve()
         max_bytes = 0
-        with open(local_path, 'rb') as f:
+        with FCPath(filepath).open('rb') as f:
             for line in f:
                 max_bytes = max(max_bytes, len(line))
 

--- a/pdstemplate/__init__.py
+++ b/pdstemplate/__init__.py
@@ -857,7 +857,8 @@ class PdsTemplate:
             str: The basename of the filepath (the final filename).
         """
 
-        return os.path.basename(filepath)
+        return FCPath(filepath).name
+#        return os.path.basename(filepath)
 
     @staticmethod
     def BOOL(value, true='true', false='false'):
@@ -1055,6 +1056,7 @@ class PdsTemplate:
             int: The size in bytes of the file.
         """
 
+        filepath = FCPath(filepath).retrieve()
         return os.path.getsize(filepath)
 
     # From http://stackoverflow.com/questions/3431825/-
@@ -1069,6 +1071,7 @@ class PdsTemplate:
             str: The MD5 checksum of the file.
         """
 
+        filepath = FCPath(filepath).retrieve()
         blocksize = 65536
         with open(filepath, 'rb') as f:
             hasher = hashlib.md5()
@@ -1094,6 +1097,7 @@ class PdsTemplate:
 
         # We intentionally open this in non-binary mode so we don't have to contend with
         # line terminator issues.
+        filepath = FCPath(filepath).retrieve()
         printable = string.printable.encode('latin8')
         with open(filepath, 'rb') as f:
             count = 0
@@ -1125,6 +1129,9 @@ class PdsTemplate:
             `filepath` in the form "yyyy-mm-ddThh:mm:ss".
         """
 
+        filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
+                                               ## time, but it's better than a crash
+#        timestamp = FCPath(filepath).stat().st_mtime  ### not implemented in FCPath
         timestamp = os.path.getmtime(filepath)
         return datetime.datetime.fromtimestamp(timestamp).isoformat()[:19]
 
@@ -1140,6 +1147,9 @@ class PdsTemplate:
             form "yyyy-mm-ddThh:mm:ssZ".
         """
 
+        filepath = FCPath(filepath).retrieve() ## this will just return the last retrieved
+                                               ## time, but it's better than a crash
+#        timestamp = FCPath(filepath).stat().st_mtime  ### not implemented in FCPath
         timestamp = os.path.getmtime(filepath)
         try:
             utc_dt = datetime.datetime.fromtimestamp(timestamp, datetime.UTC)
@@ -1261,6 +1271,7 @@ class PdsTemplate:
 
         # We intentionally open this in non-binary mode so we don't have to contend with
         # line terminator issues.
+        filepath = FCPath(filepath).retrieve()
         max_bytes = 0
         with open(filepath, 'rb') as f:
             for line in f:

--- a/pdstemplate/_pdsblock.py
+++ b/pdstemplate/_pdsblock.py
@@ -146,6 +146,7 @@ class _PdsBlock(object):
         """
 
         if expression:
+#            print(expression)
             try:
                 return eval(expression, state.global_dict, state.local_dicts[-1])
 
@@ -217,6 +218,8 @@ class _PdsBlock(object):
             # Odd-numbered items are expressions
             else:
                 (expression, name, line) = item
+#                print(self.preprocessed)
+#                from IPython import embed; print('+++++++++++++'); embed()
                 value = self.evaluate_expression(expression, line, state)
 
                 if name and not _PdsBlock._is_error(value):

--- a/pdstemplate/_pdsblock.py
+++ b/pdstemplate/_pdsblock.py
@@ -146,7 +146,6 @@ class _PdsBlock(object):
         """
 
         if expression:
-#            print(expression)
             try:
                 return eval(expression, state.global_dict, state.local_dicts[-1])
 
@@ -218,8 +217,6 @@ class _PdsBlock(object):
             # Odd-numbered items are expressions
             else:
                 (expression, name, line) = item
-#                print(self.preprocessed)
-#                from IPython import embed; print('+++++++++++++'); embed()
                 value = self.evaluate_expression(expression, line, state)
 
                 if name and not _PdsBlock._is_error(value):


### PR DESCRIPTION
Several utility functions have been modified to accept a `FCPath` argument.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public utilities now accept multiple path formats (strings, Path objects, and custom file-path objects), improving support for local and remote/cloud paths.
  * File metadata (size, hash, record counts) and reads operate consistently across path types; modification times are returned in standardized ISO/Zulu form.

* **Documentation**
  * Docstrings updated to reflect expanded input types and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->